### PR TITLE
[DOCS] Add Code Climate Badges to Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Maintainability](https://api.codeclimate.com/v1/badges/5a859231c4b77617e44f/maintainability)](https://codeclimate.com/github/Connor-Bernard/q2q/maintainability) [![Test Coverage](https://api.codeclimate.com/v1/badges/5a859231c4b77617e44f/test_coverage)](https://codeclimate.com/github/Connor-Bernard/q2q/test_coverage)
+
 # README
 
 This README would normally document whatever steps are necessary to get the


### PR DESCRIPTION
# About

We should show the code climate on the main page in the readme.

# Changes

- Add code climate maintainability badge
- Add code climate coverage badge

# Test

- N/A