### PR TITLE
[CHORE] Update Bundler

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -88,6 +88,7 @@ GEM
     debug (1.9.1)
       irb (~> 1.10)
       reline (>= 0.3.8)
+    diff-lcs (1.5.1)
     drb (2.2.0)
       ruby2_keywords
     erubi (1.12.0)
@@ -179,6 +180,23 @@ GEM
       psych (>= 4.0.0)
     reline (0.4.2)
       io-console (~> 0.5)
+    rspec-core (3.12.2)
+      rspec-support (~> 3.12.0)
+    rspec-expectations (3.12.3)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.12.0)
+    rspec-mocks (3.12.6)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.12.0)
+    rspec-rails (5.0.3)
+      actionpack (>= 5.2)
+      activesupport (>= 5.2)
+      railties (>= 5.2)
+      rspec-core (~> 3.10)
+      rspec-expectations (~> 3.10)
+      rspec-mocks (~> 3.10)
+      rspec-support (~> 3.10)
+    rspec-support (3.12.1)
     ruby2_keywords (0.0.5)
     sprockets (4.2.1)
       concurrent-ruby (~> 1.0)
@@ -221,6 +239,7 @@ DEPENDENCIES
   pg
   puma (>= 5.0)
   rails (~> 7.1.3)
+  rspec-rails (~> 5.0.0)
   sprockets-rails
   sqlite3
   stimulus-rails
@@ -232,4 +251,4 @@ RUBY VERSION
    ruby 3.2.3p157
 
 BUNDLED WITH
-   2.4.19
+   2.5.5


### PR DESCRIPTION
[Pivitol Story](https://www.pivotaltracker.com/story/show/186966413)

# About

Bundler is slightly outdated which causes issues with VSCode's recommended Ruby LSP. To get around this issue, we should update the Bundler version.

# Changes

- Updated bundler from 2.4.19 to 2.5.5

# Testing

- N/A